### PR TITLE
Specify SETUP_ERROR responses

### DIFF
--- a/Protocol.md
+++ b/Protocol.md
@@ -173,6 +173,9 @@ Setup header.
 |  Type                          | Value  | Description |
 |:-------------------------------|:-------|:------------|
 | __RESERVED__                   | 0x0000 | __Reserved__ |
+| __INVALID_SETUP__              | 0x0001 | The Setup frame is invalid for the server (it could be that the client is too recent for the old server) |
+| __UNSUPPORTED_SETUP__          | 0x0010 | Some (or all) of the parameters specified by the client are unsupported by the server |
+| __REJECTED_SETUP__             | 0x0100 | The server rejected the setup, it can specify the reason in the payload |
 | __RESERVED__                   | 0xFFFF | __Reserved__ |
 
 ### Lease Frame


### PR DESCRIPTION
In this pull request, I propose to define three categories of SETUP_ERROR: Invalid, Unsupported and Rejected.
- Invalid correspond to any message that the server can't read or understand, this should be the response that you receive if you send random data.
- Unsupported correspond to a message containing parameters that are unsupported by the server (e.g. encoding, or future capabilities)
- Rejected correspond to an decision made by the server to reject the message (e.g. the server is slowly starting or is overcapacity)