### PR TITLE
Metadata Push must be for the connection (stream id 0)

### DIFF
--- a/Protocol.md
+++ b/Protocol.md
@@ -560,7 +560,7 @@ Frame Contents
 
 * __Flags__:
      * (__M__)etadata: Metdadata _always_ present
-* __Stream ID__: May be 0 to pertain to the entire connection.
+* __Stream ID__: Must be 0 to pertain to the entire connection.
 
 ### Extension Frame
 


### PR DESCRIPTION
Frame Header Format says stream id must be present, but the spec also says Metadata for a request or response should be in the existing Frame.  So this should be a must.
