### PR TITLE
correct stream ids to match HTTP/2

### DIFF
--- a/Protocol.md
+++ b/Protocol.md
@@ -140,7 +140,7 @@ Stream ID value of 0 is reserved for any operation involving the connection.
 A stream ID must be locally unique for a Requester in a connection.
 
 Stream ID generation follows general guidelines for [HTTP/2](https://tools.ietf.org/html/rfc7540) with respect
-to odd/even values. In other words, a client MUST generate even Stream IDs and a server MUST generate odd Stream IDs.
+to odd/even values. In other words, a client MUST generate odd Stream IDs and a server MUST generate even Stream IDs.
 
 ### Frame Types
 


### PR DESCRIPTION
From the HTTP/2 spec

> Streams are identified with an unsigned 31-bit integer.  Streams initiated by a client MUST use odd-numbered stream identifiers; those initiated by the server MUST use even-numbered stream identifiers.  A stream identifier of zero (0x0) is used for connection control messages; the stream identifier of zero cannot be used to establish a new stream.