### PR TITLE
Fixes Issue #111

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -111,17 +111,13 @@ Modern distributed system topologies tend to have multiple levels of request fan
 
 Let's imagine a server responsible for computing the nth digit of Pi. A client sends a request to that server but realizes later that it doesn't want/need the response anymore (for arbitrary reasons). Rather than letting the server do the computation in vain, it can cancel it (the server may not even have started the work).
 
-#### What are example use cases of topic subscription (and push notification)?
-
-Let's imagine a chat server, you want to receive all the messages said in the chat server but you don't want to poll or continuously poll (long polling technique). Subscription is the perfect use case for that.
-
 #### What are example use cases of fire-and-forget versus request-response?
 
 Some requests don't require a response, and when it's fine to simply ignore any failure to send them, fire-and-forget is the right solution. An example could be non-critical metrics tracking in environments where UDP is inappropriate.
 
 #### What are example use cases of request-stream?
 
-Let's use the same example as for subscription, the chat server, but this time we want to subscribe to a particular chat room and ignore all other messages.
+Let's imagine a chat server, you want to receive all the messages said in the chat server but you don't want to poll or continuously poll (long polling technique). request-stream is the perfect use case for that.
 
 #### Why Binary?
 

--- a/Motivations.md
+++ b/Motivations.md
@@ -116,32 +116,22 @@ Usage can be thought of like this:
 Future<Payload> response = socketClient.requestResponse(requestPayload);
 ```
 
-##### Request/Stream (multi-response, finite) 
+##### Request/Stream (multi-response) 
 
 Extending from request/response is request/stream, which allows multiple values to be streamed back. Think of this as a "collection" or "list" response, but instead of getting back all the data as a single response, each element is streamed back in order.
+A stream may be finite or infinite. An infinite stream will not have any terminal event but may cancel.
 
 Use cases could include things like:
 
 - fetching a list of videos
 - fetching products in a catalog
 - retrieving a file line-by-line
+- Infinite event streams that continuously emit, such as metrics, or stock prices.
 
 Usage can be thought of like this:
 
 ```java
 Publisher<Payload> response = socketClient.requestStream(requestPayload);
-```
-
-##### Topic Subscription (multi-response, infinite) 
-
-Similar to request/stream is topic subscription (also known as requestSubscription). It is the same as request/stream, except it does not emit a successful terminal event (but it can terminate with an error). In other words, it is intended to be infinite until the client unsubscribes (cancels).
-
-This is a semantic difference from request/stream to allow applications to treat subscriptions differently. This interaction model targets use cases such as push notifications, or "hot" event streams that continuously emit, such as metrics, or stock prices. 
-
-Usage can be thought of like this:
-
-```java
-Publisher<Payload> response = socketClient.requestSubscription(topicSubscription);
 ```
 
 ##### Channel

--- a/Protocol.md
+++ b/Protocol.md
@@ -168,13 +168,12 @@ to odd/even values. In other words, a client MUST generate even Stream IDs and a
 | __REQUEST_RESPONSE__           | 0x0004 | __Request Response__: Request single response. |
 | __REQUEST_FNF__                | 0x0005 | __Fire And Forget__: A single one-way message. |
 | __REQUEST_STREAM__             | 0x0006 | __Request Stream__: Request a completable stream. |
-| __REQUEST_SUB__                | 0x0007 | __Request Subscription__: Request an infinite stream. |
-| __REQUEST_CHANNEL__            | 0x0008 | __Request Channel__: Request a completable stream in both directions. |
-| __REQUEST_N__                  | 0x0009 | __Request N__: Request N more items with ReactiveStreams semantics. |
-| __CANCEL__                     | 0x000A | __Cancel Request__: Cancel outstanding request. |
-| __RESPONSE__                   | 0x000B | __Response__: Response to a request. |
-| __ERROR__                      | 0x000C | __Error__: Error at connection or application level. |
-| __METADATA_PUSH__              | 0x000D | __Metadata__: Asynchronous Metadata frame |
+| __REQUEST_CHANNEL__            | 0x0007 | __Request Channel__: Request a completable stream in both directions. |
+| __REQUEST_N__                  | 0x0008 | __Request N__: Request N more items with ReactiveStreams semantics. |
+| __CANCEL__                     | 0x0009 | __Cancel Request__: Cancel outstanding request. |
+| __RESPONSE__                   | 0x000A | __Response__: Response to a request. |
+| __ERROR__                      | 0x000B | __Error__: Error at connection or application level. |
+| __METADATA_PUSH__              | 0x000C | __Metadata__: Asynchronous Metadata frame |
 | __EXT__                        | 0xFFFF | __Extension Header__: Used To Extend more frame types as well as extensions. |
 
 ### Setup Frame
@@ -431,31 +430,6 @@ Frame Contents
     * (__M__)etadata: Metadata present
     * (__F__)ollows: More Fragments Follow This Fragment.
 * __Initial Request N__: initial request N value for stream.
-* __Request Data__: identification of the service being requested along with parameters for the request.
-
-### Request Subscription Frame
-
-Frame Contents
-
-```
-     0                   1                   2                   3
-     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-    |R|                    Frame Length (optional)                  |
-    +-------------------------------+-+-+-+-------------------------+
-    |     Frame Type = REQUEST_SUB  |0|M|F|       Flags             |
-    +-------------------------------+-+-+-+-------------------------+
-    |                           Stream ID                           |
-    +---------------------------------------------------------------+
-    |                      Initial Request N                        |
-    +---------------------------------------------------------------+
-                           Metadata & Request Data
-```
-
-* __Flags__:
-    * (__M__)etadata: Metadata present
-    * (__F__)ollows: More Fragments Follow This Fragment.
-* __Initial Request N__: initial request N value for subscription.
 * __Request Data__: identification of the service being requested along with parameters for the request.
 
 ### Request Channel Frame
@@ -769,33 +743,6 @@ Upon sending a CANCEL, the stream is terminated on the Requester.
 Upon receiving a COMPLETE or ERROR, the stream is terminated on the Requester.
 
 Upon sending a COMPLETE or ERROR, the stream is terminated on the Responder.
-
-### Request Subscription
-
-1. RQ -> RS: REQUEST_SUBSCRIPTION
-1. RS -> RQ: RESPONSE*
-
-or
-
-1. RQ -> RS: REQUEST_SUBSCRIPTION
-1. RS -> RQ: RESPONSE*
-1. RS -> RQ: ERROR
-
-or
-
-1. RQ -> RS: REQUEST_SUBSCRIPTION
-1. RS -> RQ: RESPONSE*
-1. RQ -> RS: CANCEL
-
-At any time, a client may send REQUEST_N frames.
-
-Upon receiving a CANCEL, the stream is terminated on the Responder.
-
-Upon sending a CANCEL, the stream is terminated on the Requester.
-
-Upon receiving a ERROR, the stream is terminated on the Requester.
-
-Upon sending a ERROR, the stream is terminated on the Responder.
 
 ### Request Channel
 


### PR DESCRIPTION
As discussed in #111, this change removes request-subscription interaction model from the protocol.

**Frame type values have changed.** I did not want to leave a hole in the frame type flags, so I changed the flags specified after `request-subscription`. Yays/Nays?