### PR TITLE
Add additional spec for 'request N' format

### DIFF
--- a/Motivations.md
+++ b/Motivations.md
@@ -43,7 +43,7 @@ This protocol is designed for use both in datacenter, server-to-server, use case
 
 ##### "Reactive Stream" `request(n)` Async Pull
 
-This first form of flow control is suited to both server-to-server and server-to-device use cases. It is inspired by the Reactive Streams [Subscription.request(n)](https://github.com/reactive-streams/reactive-streams-jvm/blob/v1.0.0/README.md#3-subscription-code) behavior. [RxJava](https://github.com/ReactiveX/RxJava/wiki/Backpressure#how-a-subscriber-establishes-reactive-pull-backpressure), [Reactor](https://github.com/reactor/reactor), and [Akka Streams](http://doc.akka.io/docs/akka-stream-and-http-experimental/1.0-M2/stream-design.html) are examples of implementations using this form of "async pull-push" flow control.
+This first form of flow control is suited to both server-to-server and server-to-device use cases. It is inspired by the Reactive Streams [Subscription.request(n)](https://github.com/reactive-streams/reactive-streams-jvm/blob/v1.0.0/README.md#3-subscription-code) behavior. [RxJava](https://github.com/ReactiveX/RxJava/wiki/Backpressure#how-a-subscriber-establishes-reactive-pull-backpressure), [Reactor](https://github.com/reactor/reactor), and [Akka Streams](http://doc.akka.io/docs/akka/2.4/scala/stream/index.html) are examples of implementations using this form of "async pull-push" flow control.
 
 ReactiveSocket allows for the `request(n)` signal to be composed over network boundaries from requester to responder (typically client to server). This controls the flow of emission from responder to requestor using Reactive Stream semantics at the application level and enables use of bounded buffers so rate of flow adjusts to application consumption and not rely solely on transport and network buffering.
 

--- a/Protocol.md
+++ b/Protocol.md
@@ -82,7 +82,7 @@ is not present if the Frame Length is not used [see below](#frame-length).
 reception. Flags generally depend on Frame Type, but all frame types must provide space for the following flags:
      * (__I__)gnore: Ignore frame if not understood
      * (__M__)etadata: Metadata present
-* __Stream ID__: (32) Stream Identifier for this frame or 0 to indicate the entire connection.
+* __Stream ID__: (32) Positive signed integer representing the stream Identifier for this frame or 0 to indicate the entire connection.
 
 __NOTE__: Byte ordering is assumed to be big endian.
 
@@ -141,7 +141,7 @@ If Metadata Length is greater than this value, the entire frame MUST be ignored.
     +---------------------------------------------------------------+
 ```
 
-* __Metadata Length__: (31 = max 2,147,483,647 bytes) Length of Metadata in bytes. Including Metadata header. The __R__ bit is reserved and must be set to 0.
+* __Metadata Length__: (31 = max 2,147,483,647 bytes) unsigned positive Integer representing the length of Metadata in bytes. Including Metadata header. The __R__ bit is reserved and must be set to 0.
 
 ### Stream Identifiers
 
@@ -265,7 +265,7 @@ Frame Contents
 * __Error Code__: Type of Error.
 * __Error Data__: includes payload describing error information. Error Data SHOULD be a UTF-8 encoded string. The string MUST NOT be null terminated.
 
-A Stream ID of 0 means the error pertains to the connection. Including connection establishment. A non-0 Stream ID
+A Stream ID of 0 means the error pertains to the connection. Including connection establishment. A positive non-0 Stream ID
 means the error pertains to a given stream.
 
 The Error Data is typically an Exception message, but could include stringified stacktrace information if appropriate.  
@@ -433,6 +433,10 @@ Frame Contents
 * __Initial Request N__: 32-bit signed integer representing the initial request N value for the stream. Only positive values are allowed.
 * __Request Data__: identification of the service being requested along with parameters for the request.
 
+Please note that this explicitly does NOT follow the same rule as number 17 in https://github.com/reactive-streams/reactive-streams-jvm/blob/v1.0.0/README.md#3-subscription-code
+
+While reactivestreams support a demand of up to 2^63-1, and treats 2^63-1 as a magic number after which it is not necessary to track demand, this is not the case for reactivesocket. Reactivesocket only uses 4 bytes instead of 8, because we want to prioritize flow control over the network over supporting a "magic number".
+
 ### Request Subscription Frame
 
 Frame Contents
@@ -457,6 +461,8 @@ Frame Contents
     * (__F__)ollows: More Fragments Follow This Fragment.
 * __Initial Request N__: 32-bit signed integer representing the initial request N value for subscription. Only positive values are allowed.
 * __Request Data__: identification of the service being requested along with parameters for the request.
+
+See Request Stream Frame for additional information.
 
 ### Request Channel Frame
 
@@ -485,6 +491,8 @@ Frame Contents
 * __Initial Request N__: 32-bit signed integer representing the initial request N value for channel. Only positive values are allowed.
 * __Request Data__: identification of the service being requested along with parameters for the request.
 
+See Request Stream Frame for additional information.
+
 ### Request N Frame
 
 Frame Contents
@@ -506,6 +514,8 @@ Frame Contents
 * __Flags__:
      * (__M__)etadata: Metadata __NOT__ present
 * __Request N__: 32-bit signed integer value of items to request. Only positive values are allowed.
+
+See Request Stream Frame for additional information.
 
 ### Cancel Frame
 

--- a/Protocol.md
+++ b/Protocol.md
@@ -430,7 +430,7 @@ Frame Contents
 * __Flags__:
     * (__M__)etadata: Metadata present
     * (__F__)ollows: More Fragments Follow This Fragment.
-* __Initial Request N__: 32-bit signed integer representing the initial request N value for subscription. Only positive values are allowed.
+* __Initial Request N__: 32-bit signed integer representing the initial request N value for the stream. Only positive values are allowed.
 * __Request Data__: identification of the service being requested along with parameters for the request.
 
 ### Request Subscription Frame

--- a/Protocol.md
+++ b/Protocol.md
@@ -447,7 +447,7 @@ Frame Contents
     +-------------------------------+-+-+-+-------------------------+
     |                           Stream ID                           |
     +---------------------------------------------------------------+
-    |I|                    Initial Request N                        |
+    |0|                    Initial Request N                        |
     +---------------------------------------------------------------+
                            Metadata & Request Data
 ```
@@ -455,7 +455,7 @@ Frame Contents
 * __Flags__:
     * (__M__)etadata: Metadata present
     * (__F__)ollows: More Fragments Follow This Fragment.
-* __Initial Request N__: 31-bit unsigned integer representing the initial request N value for subscription. If the __I__-bit is set, it is treated as infinite
+* __Initial Request N__: 32-bit signed integer representing the initial request N value for subscription. Only positive values are allowed.
 * __Request Data__: identification of the service being requested along with parameters for the request.
 
 ### Request Channel Frame
@@ -472,7 +472,7 @@ Frame Contents
     +-------------------------------+-+-+-+-+-+---------------------+
     |                           Stream ID                           |
     +---------------------------------------------------------------+
-    |I|            Initial Request N (only if N bit set)            |
+    |0|            Initial Request N (only if N bit set)            |
     +---------------------------------------------------------------+
                            Metadata & Request Data
 ```
@@ -482,7 +482,7 @@ Frame Contents
     * (__F__)ollows: More Fragments Follow This Fragment.
     * (__C__)omplete: bit to indicate COMPLETE.
     * (__N__): Is Initial Request N present or not
-* __Initial Request N__: 31-bit unsigned integer representing the initial request N value for channel. If the __I__-bit is set, it is treated as infinite
+* __Initial Request N__: 32-bit signed integer representing the initial request N value for channel. Only positive values are allowed.
 * __Request Data__: identification of the service being requested along with parameters for the request.
 
 ### Request N Frame
@@ -499,13 +499,13 @@ Frame Contents
     +-------------------------------+-+-+---------------------------+
     |                           Stream ID                           |
     +---------------------------------------------------------------+
-    |I|                         Request N                           |
+    |0|                         Request N                           |
     +---------------------------------------------------------------+
 ```
 
 * __Flags__:
      * (__M__)etadata: Metadata __NOT__ present
-* __Request N__: 31-bit unsigned integer value of items to request. If the __I__-bit is set, it is treated as infinite
+* __Request N__: 32-bit signed integer value of items to request. Only positive values are allowed.
 
 ### Cancel Frame
 

--- a/Protocol.md
+++ b/Protocol.md
@@ -430,7 +430,7 @@ Frame Contents
 * __Flags__:
     * (__M__)etadata: Metadata present
     * (__F__)ollows: More Fragments Follow This Fragment.
-* __Initial Request N__: initial request N value for stream.
+* __Initial Request N__: 32-bit signed integer representing the initial request N value for subscription. Only positive values are allowed.
 * __Request Data__: identification of the service being requested along with parameters for the request.
 
 ### Request Subscription Frame
@@ -447,7 +447,7 @@ Frame Contents
     +-------------------------------+-+-+-+-------------------------+
     |                           Stream ID                           |
     +---------------------------------------------------------------+
-    |0|                    Initial Request N                        |
+    |                      Initial Request N                        |
     +---------------------------------------------------------------+
                            Metadata & Request Data
 ```
@@ -472,7 +472,7 @@ Frame Contents
     +-------------------------------+-+-+-+-+-+---------------------+
     |                           Stream ID                           |
     +---------------------------------------------------------------+
-    |0|            Initial Request N (only if N bit set)            |
+    |              Initial Request N (only if N bit set)            |
     +---------------------------------------------------------------+
                            Metadata & Request Data
 ```
@@ -499,7 +499,7 @@ Frame Contents
     +-------------------------------+-+-+---------------------------+
     |                           Stream ID                           |
     +---------------------------------------------------------------+
-    |0|                         Request N                           |
+    |                           Request N                           |
     +---------------------------------------------------------------+
 ```
 

--- a/Protocol.md
+++ b/Protocol.md
@@ -447,7 +447,7 @@ Frame Contents
     +-------------------------------+-+-+-+-------------------------+
     |                           Stream ID                           |
     +---------------------------------------------------------------+
-    |                      Initial Request N                        |
+    |I|                    Initial Request N                        |
     +---------------------------------------------------------------+
                            Metadata & Request Data
 ```
@@ -455,7 +455,7 @@ Frame Contents
 * __Flags__:
     * (__M__)etadata: Metadata present
     * (__F__)ollows: More Fragments Follow This Fragment.
-* __Initial Request N__: initial request N value for subscription.
+* __Initial Request N__: 31-bit unsigned integer representing the initial request N value for subscription. If the __I__-bit is set, it is treated as infinite
 * __Request Data__: identification of the service being requested along with parameters for the request.
 
 ### Request Channel Frame
@@ -472,7 +472,7 @@ Frame Contents
     +-------------------------------+-+-+-+-+-+---------------------+
     |                           Stream ID                           |
     +---------------------------------------------------------------+
-    |              Initial Request N (only if N bit set)            |
+    |I|            Initial Request N (only if N bit set)            |
     +---------------------------------------------------------------+
                            Metadata & Request Data
 ```
@@ -482,7 +482,7 @@ Frame Contents
     * (__F__)ollows: More Fragments Follow This Fragment.
     * (__C__)omplete: bit to indicate COMPLETE.
     * (__N__): Is Initial Request N present or not
-* __Initial Request N__: initial request N value for channel.
+* __Initial Request N__: 31-bit unsigned integer representing the initial request N value for channel. If the __I__-bit is set, it is treated as infinite
 * __Request Data__: identification of the service being requested along with parameters for the request.
 
 ### Request N Frame
@@ -499,13 +499,13 @@ Frame Contents
     +-------------------------------+-+-+---------------------------+
     |                           Stream ID                           |
     +---------------------------------------------------------------+
-    |                           Request N                           |
+    |I|                         Request N                           |
     +---------------------------------------------------------------+
 ```
 
 * __Flags__:
      * (__M__)etadata: Metadata __NOT__ present
-* __Request N__: integer value of items to request.
+* __Request N__: 31-bit unsigned integer value of items to request. If the __I__-bit is set, it is treated as infinite
 
 ### Cancel Frame
 


### PR DESCRIPTION
Currently, the format of the request N is ambiguous, and the allowed ranges are not specified. This causes problems with cross platform streams and subscriptions.