### PR TITLE
Supported Transports

### DIFF
--- a/Protocol.md
+++ b/Protocol.md
@@ -68,7 +68,7 @@ The ReactiveSocket protocol uses a lower level transport protocol to carry React
 An implementation MAY "close" a transport connection due to protocol processing. When this occurs, it is assumed that that connection will
 have no further frames sent and all frames will be ignored.
 
-ReactiveSocket as specified here only allows for TCP, WebSocket, and Aeron as transport protocols.
+ReactiveSocket as specified here has been designed for and tested with TCP, WebSocket, and Aeron as transport protocols.
 
 ### Framing Protocol Usage
 


### PR DESCRIPTION
The current version of Protocol.md states this:

> ReactiveSocket as specified here only allows for TCP, WebSocket, and Aeron as transport protocols.

Then in the next section, a couple paragraph away it mentions HTTP/2 as needing frame length.

It is confusing to say the protocol only supports TCP, WebSocket, and Aeron, and then mention "HTTP/2" and "Other" in the framing section. 

In this change I propose a possible wording to resolve the confusion. But I'm not quite sure what was meant by this sentence, when the section itself is also permitting other transports. 

So what is trying to be said, and what can we do to make this clearer?