### PR TITLE
Add RESPONSE Next Flag

### DIFF
--- a/Protocol.md
+++ b/Protocol.md
@@ -557,7 +557,7 @@ Frame Contents
     * (__N__)ext: bit to indicate Next (Response Data).
        * If set, `onNext` will be invoked on Subscriber/Observer.
     * (__C__)omplete: bit to indicate COMPLETE.
-       * If set, `onComplete` will be invokved on Subscriber/Observer.
+       * If set, `onComplete` will be invoked on Subscriber/Observer.
 * __Response Data__: payload for Reactive Streams onNext.
 
 A Response is generally referred to as a NEXT.

--- a/Protocol.md
+++ b/Protocol.md
@@ -546,7 +546,7 @@ Frame Contents
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
     |                           Stream ID                           |
     +---------------+-+-+-+-+-------+-------------------------------+
-    |   Frame Type  |0|M|F|C| Flags |
+    |   Frame Type  |0|M|F|N|C| ... |
     +-------------------------------+-------------------------------+
                          Metadata & Response Data
 ```
@@ -554,7 +554,10 @@ Frame Contents
 * __Flags__:
     * (__M__)etadata: Metadata Present.
     * (__F__)ollows: More fragments follow this fragment.
+    * (__N__)ext: bit to indicate Next (Response Data).
+       * If set, `onNext` will be invoked on Subscriber/Observer.
     * (__C__)omplete: bit to indicate COMPLETE.
+       * If set, `onComplete` will be invokved on Subscriber/Observer.
 * __Response Data__: payload for Reactive Streams onNext.
 
 A Response is generally referred to as a NEXT.

--- a/Protocol.md
+++ b/Protocol.md
@@ -555,9 +555,9 @@ Frame Contents
     * (__M__)etadata: Metadata Present.
     * (__F__)ollows: More fragments follow this fragment.
     * (__N__)ext: bit to indicate Next (Response Data and/or Metadata present).
-       * If set, `onNext` will be invoked on Subscriber/Observer.
+       * If set, `onNext(Payload)` or equivalent will be invoked on Subscriber/Observer.
     * (__C__)omplete: bit to indicate COMPLETE.
-       * If set, `onComplete` will be invoked on Subscriber/Observer.
+       * If set, `onComplete()` or equivalent will be invoked on Subscriber/Observer.
 * __Response Data__: payload for Reactive Streams onNext.
 
 A Response is generally referred to as a NEXT.

--- a/Protocol.md
+++ b/Protocol.md
@@ -554,7 +554,7 @@ Frame Contents
 * __Flags__:
     * (__M__)etadata: Metadata Present.
     * (__F__)ollows: More fragments follow this fragment.
-    * (__N__)ext: bit to indicate Next (Response Data).
+    * (__N__)ext: bit to indicate Next (Response Data and/or Metadata present).
        * If set, `onNext` will be invoked on Subscriber/Observer.
     * (__C__)omplete: bit to indicate COMPLETE.
        * If set, `onComplete` will be invoked on Subscriber/Observer.


### PR DESCRIPTION
As per discussion in https://github.com/ReactiveSocket/reactivesocket/issues/126 in order to remove ambiguity and use of sentinel value of 0-bytes, and allow 0-byte payloads.