### PR TITLE
Standardize the name "ReactiveSocket"

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -1,6 +1,6 @@
 ### FAQ
 
-#### Why a new protocol? 
+#### Why a new protocol?
 
 The full explanation of motivations can be found in [Motivations.md](https://github.com/ReactiveSocket/reactivesocket/blob/master/Motivations.md).
 
@@ -15,7 +15,7 @@ Some of the key reasons include:
 
 #### Why not HTTP/2?
 
-HTTP/2 is **much** better for browsers and request/response document transfer, but unfortunately does not expose interaction models beyond request/response, nor support application-level flow control. 
+HTTP/2 is **much** better for browsers and request/response document transfer, but unfortunately does not expose interaction models beyond request/response, nor support application-level flow control.
 
 Here are some quotes from the HTTP/2 spec and FAQ that are useful to provide context on what HTTP/2 was targeting:
 
@@ -37,9 +37,9 @@ See also the ReactiveSocket [Motivations document](https://github.com/ReactiveSo
 
 #### Why "Reactive Streams" `request(n)` Flow Control?
 
-Without application feedback in terms of work units done (not bytes), it is easy to cause "head of line blocking", overwhelm network and application buffers, and produce more data on the server than the client can handle. This is particularly bad when multiplexing multiple streams over a single connection where one stream can starve all others. Application layer `request(n)` semantics allows the consumer to signal how much it can receive on each stream, and allow the producer to interleave multiple streams together. 
+Without application feedback in terms of work units done (not bytes), it is easy to cause "head of line blocking", overwhelm network and application buffers, and produce more data on the server than the client can handle. This is particularly bad when multiplexing multiple streams over a single connection where one stream can starve all others. Application layer `request(n)` semantics allows the consumer to signal how much it can receive on each stream, and allow the producer to interleave multiple streams together.
 
-Following are further details on some problems that can occur when using TCP and relying solely on its flow control: 
+Following are further details on some problems that can occur when using TCP and relying solely on its flow control:
 
 - Data is buffered by TCP on the sender and receiver side which means that understanding what is done on the subscriber is not possible.
 - A sender who needs to send a large work unit (larger than the buffering on the TCP sender or receiver sides) is stuck in a scenario of poor behavior where the TCP connection will cycle between full and empty, and under-utilize the buffering drastically (as well as the throughput).
@@ -47,7 +47,7 @@ Following are further details on some problems that can occur when using TCP and
 
 It all comes down to what TCP is designed to do (not overrun the receiver OS buffer space or network queues) and what Reactive Streams flow control is designed to do (allow for push/pull application work unit semantics, additional dissemination models, and application control of when it is ready for more or not). This clear separation of concerns is necessary for any real system to operate efficiently.
 
-This illustrates why every single solution that doesn't have built-in flow control at the application level (pretty much every solution mentioned aside from MQTT, AMQP, and STOMP) is not well-suited for usage, and why ReactiveSocket incorporates application-level flow control as a first-class requirement. 
+This illustrates why every single solution that doesn't have built-in flow control at the application level (pretty much every solution mentioned aside from MQTT, AMQP, and STOMP) is not well-suited for usage, and why ReactiveSocket incorporates application-level flow control as a first-class requirement.
 
 #### What about Session Continuation across connections?
 
@@ -60,7 +60,7 @@ This is effectively the same as the HTTP/2 requirement to exchange SETTINGS fram
 - <https://http2.github.io/http2-spec/#ConnectionHeader>
 - <https://http2.github.io/http2-spec/#discover-http>
 
-HTTP/2 and ReactiveSocket both require a stateful connection with an initial exchange. 
+HTTP/2 and ReactiveSocket both require a stateful connection with an initial exchange.
 
 #### Transport Layer
 
@@ -74,9 +74,9 @@ Proxies that behave correctly for HTTP/2 will behave correctly for ReactiveSocke
 
 #### Frame Length
 
-On TCP, it will be included. On Aeron or WebSockets it is not needed. 
+On TCP, it will be included. On Aeron or WebSockets it is not needed.
 
-If there is some reason to include it in Aeron or WebSockets we are fine with changing. 
+If there is some reason to include it in Aeron or WebSockets we are fine with changing.
 
 #### State Spanning Connections
 
@@ -94,9 +94,9 @@ There is no way to fully future-proof something, but we have made attempts to fu
 - Separation of data and metadata
 - Use of MimeType in Setup to eliminate coupling with encoding
 
-Additionally, we have stuck within connection-oriented semantics of HTTP/2 and TCP so that connection behavior is not abnormal or special. 
+Additionally, we have stuck within connection-oriented semantics of HTTP/2 and TCP so that connection behavior is not abnormal or special.
 
-Beyond those factors, TCP has existed since 1977. We do not expect it to be eliminated in the near future. Quic looks to be a legit alternative to TCP in the coming years. Since HTTP/2 is already working over Quic, we see no reason why Reactive Socket will not also work over Quic. 
+Beyond those factors, TCP has existed since 1977. We do not expect it to be eliminated in the near future. Quic looks to be a legit alternative to TCP in the coming years. Since HTTP/2 is already working over Quic, we see no reason why ReactiveSocket will not also work over Quic.
 
 #### Prioritization, QoS, OOB
 
@@ -147,7 +147,7 @@ Relying on the TCP flow control doesn't work, because we multiplex the streams o
 
 #### How does ReactiveSocket flow control behave?
 
-There are two types of flow control: 
+There are two types of flow control:
 
 - One is provided by the request-n semantics defined in Reactive Streams (please [read the spec][Reactive Streams] for exhaustive details).
 - The second is provided via the lease semantics defined in the [Protocol document](https://github.com/ReactiveSocket/reactivesocket/blob/master/Protocol.md#lease-semantics).
@@ -164,7 +164,7 @@ For instance, when a client doesn't have a valid lease, it exposes a "0.0" avail
 
 #### Is multiplexing equivalent to pipelining?
 
-No, pipelining requires reading the responses in the order of the requests. 
+No, pipelining requires reading the responses in the order of the requests.
 
 For example, with pipelining: a client sends `reqA`, `reqB`, `reqC`. It has to receive the responses in this order: `respA`, `respB`, `respC`.
 
@@ -188,9 +188,9 @@ The interaction models could be reduced to just one "request-channel". Every oth
 - Ease of use from the client point of view.
 - Performance.
 
-#### So why the "ReactiveSocket" name? 
+#### So why the "ReactiveSocket" name?
 
-Isn't "Reactive" a totally [hyped](http://www.gartner.com/technology/research/methodologies/hype-cycle.jsp) buzzword? 
+Isn't "Reactive" a totally [hyped](http://www.gartner.com/technology/research/methodologies/hype-cycle.jsp) buzzword?
 
 This library is directly related to several projects where "Reactive" is an important part of their name and architectural pattern. Thus the choice was made to retain this relationship in the name. Specifically:
 
@@ -199,7 +199,7 @@ This library is directly related to several projects where "Reactive" is an impo
 - [Reactive Extensions] with [RxJava] and [RxJS] in particular.
 - [Reactive Manifesto] – particularly the "message-driven" aspect.
 
-ReactiveSocket implements, uses, or follows the principles in these projects and libraries, thus the name. 
+ReactiveSocket implements, uses, or follows the principles in these projects and libraries, thus the name.
 
 [Reactive Streams]: http://www.reactive-streams.org
 [Reactive Streams IO]: https://github.com/reactive-streams/reactive-streams-io

--- a/MimeTypes.md
+++ b/MimeTypes.md
@@ -5,7 +5,7 @@ This document provides a guidance for the mime types of these payloads.
 
 #### Metadata
 
-Reactive Socket provides a default mime type for metadata payloads and all implementations of the protocol MUST use this default, unless overridden by the user.
+ReactiveSocket provides a default mime type for metadata payloads and all implementations of the protocol MUST use this default, unless overridden by the user.
 
 ##### Overview
 
@@ -31,4 +31,4 @@ Indefinite length map (CBOR Major Type 5)
 
 #### Data
 
-Reactive Socket does not provide any default mime type for the data payload. Applications must pass an appropriate data payload mime type in the setup frame as specified by the protocol.
+ReactiveSocket does not provide any default mime type for the data payload. Applications must pass an appropriate data payload mime type in the setup frame as specified by the protocol.

--- a/Motivations.md
+++ b/Motivations.md
@@ -1,6 +1,6 @@
 ## Motivations
 
-Large distributed systems are often implemented in a modular fashion by different teams using a variety of technologies and programming languages. The pieces need to communicate reliably and support rapid, independent evolution. Effective and scalable communication between modules is a crucial concern in distributed systems. It significantly affects how much latency users experience and the amount of resources required to build and run the system. 
+Large distributed systems are often implemented in a modular fashion by different teams using a variety of technologies and programming languages. The pieces need to communicate reliably and support rapid, independent evolution. Effective and scalable communication between modules is a crucial concern in distributed systems. It significantly affects how much latency users experience and the amount of resources required to build and run the system.
 
 Architectural patterns documented in the [Reactive Manifesto](http://www.reactivemanifesto.org) and implemented in libraries such as [Reactive Streams](http://www.reactive-streams.org) and [Reactive Extensions](http://reactivex.io) favor asynchronous messaging and embrace communication patterns beyond request/response. This "ReactiveSocket" protocol is a formal communication protocol that embraces the "reactive" principles.
 
@@ -8,7 +8,7 @@ Following are motivations for defining a new protocol:
 
 #### Message Driven
 
-Network communication is asynchronous. The ReactiveSocket protocol embraces this and models all communication as multiplexed streams of messages over a single network connection and never synchronously blocks while waiting for a response. 
+Network communication is asynchronous. The ReactiveSocket protocol embraces this and models all communication as multiplexed streams of messages over a single network connection and never synchronously blocks while waiting for a response.
 
 The [Reactive Manifesto](http://www.reactivemanifesto.org) states:
 
@@ -39,7 +39,7 @@ It continues, discussing persistent connections:
 
 ReactiveSocket supports two forms of application-level flow control to help protect both client and server resources from being overwhelmed.
 
-This protocol is designed for use both in datacenter, server-to-server, use cases, as well as server-to-device use cases over the internet, such as to mobile devices or browsers. 
+This protocol is designed for use both in datacenter, server-to-server, use cases, as well as server-to-device use cases over the internet, such as to mobile devices or browsers.
 
 ##### "Reactive Stream" `request(n)` Async Pull
 
@@ -49,7 +49,7 @@ ReactiveSocket allows for the `request(n)` signal to be composed over network bo
 
 ##### Leasing
 
-The second form of flow control is primarily focused on server-to-server use cases in a data center. When enabled, a responder (typically a server) can issue leases to the requester based upon its knowledge of its capacity in order to control requests rates. On the requester side, this enables application level load balancing for sending messages only to responders (servers) that have signalled capacity. This signal from server to client allows for more intelligent routing and load balancing algorithms in data centers with clusters of machines. 
+The second form of flow control is primarily focused on server-to-server use cases in a data center. When enabled, a responder (typically a server) can issue leases to the requester based upon its knowledge of its capacity in order to control requests rates. On the requester side, this enables application level load balancing for sending messages only to responders (servers) that have signalled capacity. This signal from server to client allows for more intelligent routing and load balancing algorithms in data centers with clusters of machines.
 
 
 #### Polyglot Support
@@ -68,7 +68,7 @@ Thus, ReactiveSocket defines application layer semantics over these network tran
 
 A protocol that uses network resources inefficiently (repeated handshakes and connection setup and tear down overhead, bloated message format, etc.) can greatly increase the perceived latency of a system. Also, without flow control semantics, a single poorly written module can overrun the rest of the system when dependent services slow down, potentially causing retry storms that put further pressure on the system. [Hystrix](https://github.com/Netflix/Hystrix/wiki#problem) is an example solution trying to address the problems of synchronous request/response. It comes [at a cost](https://github.com/Netflix/Hystrix/wiki/FAQ#what-is-the-processing-overhead-of-using-hystrix) though in overhead and complexity.
 
-Additionally, a poorly chosen communication protocol wastes server resources (CPU, memory, network bandwidth). While that may be acceptable for smaller deployments, large systems with hundreds or thousands of nodes multiply the somewhat small inefficiencies into noticeable excess. Running with a huge footprint leaves less room for expansion as server resources are relatively cheap but not infinite. Managing giant clusters is much more expensive and less nimble even with good tools. And often forgotten, the larger a cluster is, the more operationally complex it is, which becomes an availability concern. 
+Additionally, a poorly chosen communication protocol wastes server resources (CPU, memory, network bandwidth). While that may be acceptable for smaller deployments, large systems with hundreds or thousands of nodes multiply the somewhat small inefficiencies into noticeable excess. Running with a huge footprint leaves less room for expansion as server resources are relatively cheap but not infinite. Managing giant clusters is much more expensive and less nimble even with good tools. And often forgotten, the larger a cluster is, the more operationally complex it is, which becomes an availability concern.
 
 ReactiveSocket seeks to:
 
@@ -87,16 +87,16 @@ ReactiveSocket seeks to:
 
 An inappropriate protocol increases the costs of developing a system. It can be a mismatched abstraction that forces the design of the system into the mold it allows. Then developers spend extra time working around its shortcomings to handle errors and achieve acceptable performance. In a polyglot environment this problem is amplified as different languages will use different approaches to solve this problem and requires extra coordination among teams to do so. To date the defacto standard is HTTP and everything is a request/response. In some cases this might not be the ideal communication model for a given feature.
 
-One such example is push notifications. Using request/response forces an application to do polling where the client consistently sends requests to check the server for data. One does not need to look far to find examples of applications doing high volumes of requests/second just to poll and be told there is nothing for them. This is wasteful for clients, servers, and networks, costs money, increases infrastructure size, operational complexity and thus availability. Generally it also adds latency to the user experience in receiving a notification, as polling is scaled back to longer intervals in an attempt to reduce costs. 
+One such example is push notifications. Using request/response forces an application to do polling where the client consistently sends requests to check the server for data. One does not need to look far to find examples of applications doing high volumes of requests/second just to poll and be told there is nothing for them. This is wasteful for clients, servers, and networks, costs money, increases infrastructure size, operational complexity and thus availability. Generally it also adds latency to the user experience in receiving a notification, as polling is scaled back to longer intervals in an attempt to reduce costs.
 
 For this and other reasons, ReactiveSocket is not limited to just one interaction model. The various supported interaction models described below open up powerful new possibilities for system design:
 
 
 ##### Fire-and-Forget
 
-Fire-and-forget is an optimization of request/response that is useful when a response is not needed. It allows for significant performance optimizations, not just in saved network usage by skipping the response, but also in client and server processing time as no bookkeeping is needed to wait for and associate a response or cancellation request. 
+Fire-and-forget is an optimization of request/response that is useful when a response is not needed. It allows for significant performance optimizations, not just in saved network usage by skipping the response, but also in client and server processing time as no bookkeeping is needed to wait for and associate a response or cancellation request.
 
-This interaction model is useful for use cases that support lossiness, such as non-critical event logging. 
+This interaction model is useful for use cases that support lossiness, such as non-critical event logging.
 
 Usage can be thought of like this:
 
@@ -106,7 +106,7 @@ Future<Void> completionSignalOfSend = socketClient.fireAndForget(message);
 
 ##### Request/Response (single-response)
 
-Standard request/response semantics are still supported, and still expected to represent the majority of requests over a ReactiveSocket connection. These request/response interactions can be considered optimized "streams of only 1 response", and are asynchronous messages multiplexed over a single connection. 
+Standard request/response semantics are still supported, and still expected to represent the majority of requests over a ReactiveSocket connection. These request/response interactions can be considered optimized "streams of only 1 response", and are asynchronous messages multiplexed over a single connection.
 
 The consumer "waits" for the response message, so it looks like a typical request/response, but underneath it never synchronously blocks.
 
@@ -116,7 +116,7 @@ Usage can be thought of like this:
 Future<Payload> response = socketClient.requestResponse(requestPayload);
 ```
 
-##### Request/Stream (multi-response, finite) 
+##### Request/Stream (multi-response, finite)
 
 Extending from request/response is request/stream, which allows multiple values to be streamed back. Think of this as a "collection" or "list" response, but instead of getting back all the data as a single response, each element is streamed back in order.
 
@@ -134,7 +134,7 @@ Publisher<Payload> response = socketClient.requestStream(requestPayload);
 
 ##### Channel
 
-A channel is bi-directional, with a stream in both directions. 
+A channel is bi-directional, with a stream in both directions.
 
 An example use case that benefits from this interaction model is:
 
@@ -142,7 +142,7 @@ An example use case that benefits from this interaction model is:
 - deltas/diffs are emitted from server to client as changes occur
 - client update the subscription over time to add/remove criteria/topics/etc
 
-Without a bi-directional channel, the client would have to cancel the initial request, re-request and receive all data from scratch, rather than just updating the subscription and efficiently getting just the difference. 
+Without a bi-directional channel, the client would have to cancel the initial request, re-request and receive all data from scratch, rather than just updating the subscription and efficiently getting just the difference.
 
 Usage can be thought of like this:
 
@@ -152,15 +152,15 @@ Publisher<Payload> output = socketClient.requestChannel(Publisher<Payload> input
 
 #### Behaviors
 
-Beyond the interaction models above, there are other behaviors that can benefit applications and system efficiency. 
+Beyond the interaction models above, there are other behaviors that can benefit applications and system efficiency.
 
 ##### single-response vs multi-response
 
-One key difference between single-response and multi-response is how the Reactive Socket stack delivers data to the application: A single-response might be carried across multiple frames, and be part of a larger RS connection that is streaming multiple messages multiplexed. But single-response means the application only gets its data when the entire response is received. While multi-response delivers it piecemeal. This could allow the user to design its service with multi-response in mind, and then the client can start processing the data as soon as it receives the first chunk.
+One key difference between single-response and multi-response is how the ReactiveSocket stack delivers data to the application: A single-response might be carried across multiple frames, and be part of a larger RS connection that is streaming multiple messages multiplexed. But single-response means the application only gets its data when the entire response is received. While multi-response delivers it piecemeal. This could allow the user to design its service with multi-response in mind, and then the client can start processing the data as soon as it receives the first chunk.
 
 ##### Bi-Directional
 
-ReactiveSocket supports bi-directional requests where both client and server can act as requester or responder. This allows a client (such as a user device) to act as a responder to requests from the server. 
+ReactiveSocket supports bi-directional requests where both client and server can act as requester or responder. This allows a client (such as a user device) to act as a responder to requests from the server.
 
 For example, a server could query clients for trace debug information, state, etc. This can be used to reduce infrastructure scaling requirements by allowing server-side to query when needed instead of having millions/billions of clients constantly submitting data that may only occasionally be needed. This also opens up future interaction models currently not envisioned between client and server.
 
@@ -173,9 +173,9 @@ All streams (including request/response) support cancellation to allow efficient
 
 Following is a brief review of some protocols reviewed before deciding to create ReactiveSocket. It is not trying to be exhaustive or detailed. It also does not seek to criticize the various protocols, as they all are good at what they are built for. This section is meant solely to express that existing protocols did not sufficiently meet the requirements that motivated the creation of ReactiveSocket.
 
-For context: 
+For context:
 
-- ReactiveSocket is an OSI Layer 5/6, or TCP/IP Application Layer protocol. 
+- ReactiveSocket is an OSI Layer 5/6, or TCP/IP Application Layer protocol.
 - It is intended for use over duplex, binary transport protocols that are TCP-like in behavior (described further [here](https://github.com/ReactiveSocket/reactivesocket/blob/master/Protocol.md#transport-protocol)).
 
 #### TCP & QUIC
@@ -200,9 +200,9 @@ These limited application semantics generally requires an application protocol t
 
 There is no defined mechanism for flow control from responder (typically server) to requestor (typically client). HTTP/2 does flow control at the byte level, not the application level. There is no defined mechanism for communicating requestor (typically server) availability other than failing a request (503). It does not support interaction models such as fire-and-forget, and streaming models are inefficient (chunked encoding or SSE, which is ASCII based).
 
-Despite its ubiquity, REST alone is insufficient and inappropriate for defining application semantics. 
+Despite its ubiquity, REST alone is insufficient and inappropriate for defining application semantics.
 
-What about HTTP/2 though? Doesn't it resolve the HTTP/1 issues and address the motivations of ReactiveSockets?
+What about HTTP/2 though? Doesn't it resolve the HTTP/1 issues and address the motivations of ReactiveSocket?
 
 Unfortunately, no. HTTP/2 is MUCH better for browsers and request/response document transfer, but does not expose the desired behaviors and interaction models for applications as described earlier in this document.
 
@@ -220,7 +220,7 @@ Additionally, "push promises" are focused on filling browser caches for standard
 
 This means we still need SSE or WebSockets (and SSE is a text protocol so requires Base64 encoding to UTF-8) for push.
 
-HTTP/2 was meant as a better HTTP/1.1, primarily for document retrieval in browsers for websites. We can do better than HTTP/2 for applications. 
+HTTP/2 was meant as a better HTTP/1.1, primarily for document retrieval in browsers for websites. We can do better than HTTP/2 for applications.
 
 #### MQTT, AMQP, ZMTP
 

--- a/Protocol.md
+++ b/Protocol.md
@@ -1,14 +1,14 @@
 ## Status
 
-This protocol is currently a draft for the final specifications. 
+This protocol is currently a draft for the final specifications.
 Current version of the protocol is __0.2__ (Major Version: 0, Minor Version: 2).
 
 ## Introduction
 
 Specify an application protocol for [Reactive Streams](http://www.reactive-streams.org/) semantics across an asynchronous, binary
-boundary. For more information, please see [Reactive Socket](http://reactivesocket.io/).
+boundary. For more information, please see [ReactiveSocket](http://reactivesocket.io/).
 
-ReactiveSockets assumes an operating paradigm. These assumptions are:
+ReactiveSocket assumes an operating paradigm. These assumptions are:
 - one-to-one communication
 - non-proxied communication. Or if proxied, the ReactiveSocket semantics and assumptions are preserved across the proxy.
 - no state preserved across [transport protocol](#transport-protocol) sessions by the protocol
@@ -22,7 +22,7 @@ Byte ordering is big endian for all fields.
 * __Frame__: A single message containing a request, response, or protocol processing.
 * __Fragment__: A portion of an application message that has been partitioned for inclusion in a Frame.
 See [Fragmentation and Reassembly](#fragmentation-and-reassembly).
-* __Transport__: Protocol used to carry ReactiveSockets protocol. One of WebSockets, TCP, or Aeron. The transport MUST
+* __Transport__: Protocol used to carry ReactiveSocket protocol. One of WebSockets, TCP, or Aeron. The transport MUST
 provide capabilities mentioned in the [transport protocol](#transport-protocol) section.
 * __Stream__: Unit of operation (request/response, etc.). See [Motivations](Motivations.md).
 * __Request__: A stream request. May be one of four types. As well as request for more items or cancellation of previous request.
@@ -90,7 +90,7 @@ When using a transport protocol providing framing, the ReactiveSocket frame is s
 ```
     +-----------------------------------------------+
     |                ReactiveSocket Frame          ...
-    |                                              
+    |
     +-----------------------------------------------+
 ```
 
@@ -103,7 +103,7 @@ When using a transport protocol that does not provide compatible framing, the Fr
     |                    Frame Length               |
     +-----------------------------------------------+
     |                ReactiveSocket Frame          ...
-    |                                              
+    |
     +-----------------------------------------------+
 ```
 
@@ -128,7 +128,7 @@ ReactiveSocket frames begin with a ReactiveSocket Frame Header. The general layo
 ```
 
 * __Stream ID__: (32) Positive signed integer representing the stream Identifier for this frame or 0 to indicate the entire connection.
-  * Transport protocols that include demultiplexing, such as HTTP/2, MAY omit the Stream ID field if all parties agree. The means of negotiation and agreement is left to the transport protocol. 
+  * Transport protocols that include demultiplexing, such as HTTP/2, MAY omit the Stream ID field if all parties agree. The means of negotiation and agreement is left to the transport protocol.
 * __Frame Type__: (6 = max 64) Type of Frame.
 * __Flags__: Any Flag bit not specifically indicated in the frame type should be set to 0 when sent and not interpreted on
 reception. Flags generally depend on Frame Type, but all frame types must provide space for the following flags:
@@ -269,7 +269,7 @@ rules MAY be used for handling layout. For example, `application/x.netflix+cbor`
 * __Setup Data__: includes payload describing connection capabilities of the endpoint sending the
 Setup header.
 
-__NOTE__: A server that receives a SETUP frame that has (__R__)esume Enabled set, but does not support resuming operation, must reject the SETUP with an ERROR. 
+__NOTE__: A server that receives a SETUP frame that has (__R__)esume Enabled set, but does not support resuming operation, must reject the SETUP with an ERROR.
 
 ### ERROR Frame (0x0B)
 
@@ -300,7 +300,7 @@ Frame Contents
 A Stream ID of 0 means the error pertains to the connection. Including connection establishment. A positive non-0 Stream ID
 means the error pertains to a given stream.
 
-The Error Data is typically an Exception message, but could include stringified stacktrace information if appropriate.  
+The Error Data is typically an Exception message, but could include stringified stacktrace information if appropriate.
 
 #### Error Codes
 
@@ -350,7 +350,7 @@ Frame Contents
                                 Metadata
 ```
 
-* __Frame Type__: (16) 0x02 
+* __Frame Type__: (16) 0x02
 * __Flags__:
      * (__M__)etadata: Metadata present
 * __Time-To-Live (TTL)__: Time (in milliseconds) for validity of LEASE from time of reception
@@ -494,7 +494,7 @@ Frame Contents
 * __Initial Request N__: 32-bit signed integer representing the initial request N value for channel. Only positive values are allowed.
 * __Request Data__: identification of the service being requested along with parameters for the request.
 
-A requester MUST send only __one__ REQUEST_CHANNEL frame. Subsequent messages from requester to responder MUST be sent as PAYLOAD frames. 
+A requester MUST send only __one__ REQUEST_CHANNEL frame. Subsequent messages from requester to responder MUST be sent as PAYLOAD frames.
 
 A requester MUST __not__ send PAYLOAD frames after the REQUEST_CHANNEL frame until the responder sends a REQUEST_N frame granting credits for number of PAYLOADs able to be sent.
 
@@ -1002,7 +1002,7 @@ RESUME frames MUST always use Stream ID 0 as they pertain to the connection.
     * (__M__)etadata: Metadata __never__ Present.
 * __Major Version__: (16) Major version number of the protocol.
 * __Minor Version__: (16) Minor version number of the protocol.
-* __Resume Identification Token Length__: (16 = max 65,536 bytes) Resume Identification Token Length in bytes. 
+* __Resume Identification Token Length__: (16 = max 65,536 bytes) Resume Identification Token Length in bytes.
 * __Resume Identification Token__: TToken used for client resume identification. Same Resume Identification used in the initial SETUP by the client.
 * __Last Received Server Position__: (64) The last implied position the client received from the server.
 * __First Available Client Position__: (64) The earliest position that the client can rewind back to prior to resending frames.


### PR DESCRIPTION
It would be nice if we always referred to ReactiveSocket as
"ReactiveSocket", and not "ReactiveSockets" or "Reactive Socket".

This PR simply fixes this inconsistency (and also removes some trailing
whitespaces).
