### PR TITLE
Replace "ReactiveSockets" and "Reactive Socket" with "ReactiveSocket"

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -96,7 +96,7 @@ There is no way to fully future-proof something, but we have made attempts to fu
 
 Additionally, we have stuck within connection-oriented semantics of HTTP/2 and TCP so that connection behavior is not abnormal or special. 
 
-Beyond those factors, TCP has existed since 1977. We do not expect it to be eliminated in the near future. Quic looks to be a legit alternative to TCP in the coming years. Since HTTP/2 is already working over Quic, we see no reason why Reactive Socket will not also work over Quic. 
+Beyond those factors, TCP has existed since 1977. We do not expect it to be eliminated in the near future. Quic looks to be a legit alternative to TCP in the coming years. Since HTTP/2 is already working over Quic, we see no reason why ReactiveSocket will not also work over Quic. 
 
 #### Prioritization, QoS, OOB
 

--- a/MimeTypes.md
+++ b/MimeTypes.md
@@ -5,7 +5,7 @@ This document provides a guidance for the mime types of these payloads.
 
 #### Metadata
 
-Reactive Socket provides a default mime type for metadata payloads and all implementations of the protocol MUST use this default, unless overridden by the user.
+ReactiveSocket provides a default mime type for metadata payloads and all implementations of the protocol MUST use this default, unless overridden by the user.
 
 ##### Overview
 
@@ -31,4 +31,4 @@ Indefinite length map (CBOR Major Type 5)
 
 #### Data
 
-Reactive Socket does not provide any default mime type for the data payload. Applications must pass an appropriate data payload mime type in the setup frame as specified by the protocol.
+ReactiveSocket does not provide any default mime type for the data payload. Applications must pass an appropriate data payload mime type in the setup frame as specified by the protocol.

--- a/Motivations.md
+++ b/Motivations.md
@@ -156,7 +156,7 @@ Beyond the interaction models above, there are other behaviors that can benefit 
 
 ##### single-response vs multi-response
 
-One key difference between single-response and multi-response is how the Reactive Socket stack delivers data to the application: A single-response might be carried across multiple frames, and be part of a larger RS connection that is streaming multiple messages multiplexed. But single-response means the application only gets its data when the entire response is received. While multi-response delivers it piecemeal. This could allow the user to design its service with multi-response in mind, and then the client can start processing the data as soon as it receives the first chunk.
+One key difference between single-response and multi-response is how the ReactiveSocket stack delivers data to the application: A single-response might be carried across multiple frames, and be part of a larger RS connection that is streaming multiple messages multiplexed. But single-response means the application only gets its data when the entire response is received. While multi-response delivers it piecemeal. This could allow the user to design its service with multi-response in mind, and then the client can start processing the data as soon as it receives the first chunk.
 
 ##### Bi-Directional
 
@@ -202,7 +202,7 @@ There is no defined mechanism for flow control from responder (typically server)
 
 Despite its ubiquity, REST alone is insufficient and inappropriate for defining application semantics. 
 
-What about HTTP/2 though? Doesn't it resolve the HTTP/1 issues and address the motivations of ReactiveSockets?
+What about HTTP/2 though? Doesn't it resolve the HTTP/1 issues and address the motivations of ReactiveSocket?
 
 Unfortunately, no. HTTP/2 is MUCH better for browsers and request/response document transfer, but does not expose the desired behaviors and interaction models for applications as described earlier in this document.
 

--- a/Protocol.md
+++ b/Protocol.md
@@ -6,9 +6,9 @@ Current version of the protocol is __0.2__ (Major Version: 0, Minor Version: 2).
 ## Introduction
 
 Specify an application protocol for [Reactive Streams](http://www.reactive-streams.org/) semantics across an asynchronous, binary
-boundary. For more information, please see [Reactive Socket](http://reactivesocket.io/).
+boundary. For more information, please see [ReactiveSocket](http://reactivesocket.io/).
 
-ReactiveSockets assumes an operating paradigm. These assumptions are:
+ReactiveSocket assumes an operating paradigm. These assumptions are:
 - one-to-one communication
 - non-proxied communication. Or if proxied, the ReactiveSocket semantics and assumptions are preserved across the proxy.
 - no state preserved across [transport protocol](#transport-protocol) sessions by the protocol
@@ -22,7 +22,7 @@ Byte ordering is big endian for all fields.
 * __Frame__: A single message containing a request, response, or protocol processing.
 * __Fragment__: A portion of an application message that has been partitioned for inclusion in a Frame.
 See [Fragmentation and Reassembly](#fragmentation-and-reassembly).
-* __Transport__: Protocol used to carry ReactiveSockets protocol. One of WebSockets, TCP, or Aeron. The transport MUST
+* __Transport__: Protocol used to carry ReactiveSocket protocol. One of WebSockets, TCP, or Aeron. The transport MUST
 provide capabilities mentioned in the [transport protocol](#transport-protocol) section.
 * __Stream__: Unit of operation (request/response, etc.). See [Motivations](Motivations.md).
 * __Request__: A stream request. May be one of four types. As well as request for more items or cancellation of previous request.


### PR DESCRIPTION
It would be nice if we always referred to ReactiveSocket as
"ReactiveSocket", and not "ReactiveSockets" or "Reactive Socket".

This PR simply fixes this inconsistency.