### PR TITLE
Standardize the name "Reactive Streams"

### DIFF
--- a/Motivations.md
+++ b/Motivations.md
@@ -41,11 +41,11 @@ ReactiveSocket supports two forms of application-level flow control to help prot
 
 This protocol is designed for use both in datacenter, server-to-server, use cases, as well as server-to-device use cases over the internet, such as to mobile devices or browsers. 
 
-##### "Reactive Stream" `request(n)` Async Pull
+##### "Reactive Streams" `request(n)` Async Pull
 
 This first form of flow control is suited to both server-to-server and server-to-device use cases. It is inspired by the Reactive Streams [Subscription.request(n)](https://github.com/reactive-streams/reactive-streams-jvm/blob/v1.0.0/README.md#3-subscription-code) behavior. [RxJava](https://github.com/ReactiveX/RxJava/wiki/Backpressure#how-a-subscriber-establishes-reactive-pull-backpressure), [Reactor](https://github.com/reactor/reactor), and [Akka Streams](http://doc.akka.io/docs/akka/2.4/scala/stream/index.html) are examples of implementations using this form of "async pull-push" flow control.
 
-ReactiveSocket allows for the `request(n)` signal to be composed over network boundaries from requester to responder (typically client to server). This controls the flow of emission from responder to requestor using Reactive Stream semantics at the application level and enables use of bounded buffers so rate of flow adjusts to application consumption and not rely solely on transport and network buffering.
+ReactiveSocket allows for the `request(n)` signal to be composed over network boundaries from requester to responder (typically client to server). This controls the flow of emission from responder to requestor using Reactive Streams semantics at the application level and enables use of bounded buffers so rate of flow adjusts to application consumption and not rely solely on transport and network buffering.
 
 ##### Leasing
 

--- a/Protocol.md
+++ b/Protocol.md
@@ -194,7 +194,7 @@ to odd/even values. In other words, a client MUST generate odd Stream IDs and a 
 | __REQUEST_FNF__                | 0x05 | __Fire And Forget__: A single one-way message. |
 | __REQUEST_STREAM__             | 0x06 | __Request Stream__: Request a completable stream. |
 | __REQUEST_CHANNEL__            | 0x07 | __Request Channel__: Request a completable stream in both directions. |
-| __REQUEST_N__                  | 0x08 | __Request N__: Request N more items with ReactiveStreams semantics. |
+| __REQUEST_N__                  | 0x08 | __Request N__: Request N more items with Reactive Streams semantics. |
 | __CANCEL__                     | 0x09 | __Cancel Request__: Cancel outstanding request. |
 | __PAYLOAD__                    | 0x0A | __Payload__: Payload on a stream. For example, response to a request, or message on a channel. |
 | __ERROR__                      | 0x0B | __Error__: Error at connection or application level. |
@@ -468,7 +468,7 @@ Frame Contents
 * __Initial Request N__: 32-bit signed integer representing the initial request N value for the stream. Only positive values are allowed.
 * __Request Data__: identification of the service being requested along with parameters for the request.
 
-See Flow Control: Reactive Stream Semantics for more information on RequestN behavior.
+See Flow Control: Reactive Streams Semantics for more information on RequestN behavior.
 
 ### REQUEST_CHANNEL Frame (0x07)
 
@@ -499,7 +499,7 @@ A requester MUST send only __one__ REQUEST_CHANNEL frame. Subsequent messages fr
 
 A requester MUST __not__ send PAYLOAD frames after the REQUEST_CHANNEL frame until the responder sends a REQUEST_N frame granting credits for number of PAYLOADs able to be sent.
 
-See Flow Control: Reactive Stream Semantics for more information on RequestN behavior.
+See Flow Control: Reactive Streams Semantics for more information on RequestN behavior.
 
 ### REQUEST_N Frame (0x08)
 
@@ -522,7 +522,7 @@ Frame Contents
      * (__M__)etadata: Metadata __NOT__ present
 * __Request N__: 32-bit signed integer value of items to request. Only positive values are allowed.
 
-See Flow Control: Reactive Stream Semantics for more information on RequestN behavior.
+See Flow Control: Reactive Streams Semantics for more information on RequestN behavior.
 
 ### CANCEL Frame (0x09)
 
@@ -838,15 +838,15 @@ Upon sending a COMPLETE or ERROR, the stream is terminated on the Responder.
 
 There are multiple flow control mechanics provided by the protocol.
 
-#### Reactive Stream Semantics
+#### Reactive Streams Semantics
 
-[Reactive Stream](http://www.reactive-streams.org/) semantics for flow control of Streams, Subscriptions, and Channels.
+[Reactive Streams](http://www.reactive-streams.org/) semantics for flow control of Streams, Subscriptions, and Channels.
 
 Please note that this explicitly does NOT follow rule number 17 in https://github.com/reactive-streams/reactive-streams-jvm/blob/v1.0.0/README.md#3-subscription-code
 
-While ReactiveStreams supports a demand of up to 2^63-1, and treats 2^63-1 as a magic number signaling to not track demand, this is not the case for ReactiveSocket. ReactiveSocket prioritizes byte size and only uses 4 bytes instead of 8 so the magic number is unavailable.
+While Reactive Streams supports a demand of up to 2^63-1, and treats 2^63-1 as a magic number signaling to not track demand, this is not the case for ReactiveSocket. ReactiveSocket prioritizes byte size and only uses 4 bytes instead of 8 so the magic number is unavailable.
 
-The Requester and the Responder MUST respect the reactive-streams semantics.
+The Requester and the Responder MUST respect the Reactive Streams semantics.
 
 e.g. here's an example of a successful stream call with flow-control.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Join the chat at https://gitter.im/ReactiveSocket/reactivesocket](https://badges.gitter.im/ReactiveSocket/reactivesocket.svg)](https://gitter.im/ReactiveSocket/reactivesocket?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-ReactiveSocket is an application protocol providing [Reactive Stream](http://www.reactive-streams.org) semantics over an asynchronous, binary boundary.
+ReactiveSocket is an application protocol providing [Reactive Streams](http://www.reactive-streams.org) semantics over an asynchronous, binary boundary.
 
 It enables the following symmetric interaction models via async message passing over a single connection:
 


### PR DESCRIPTION
Similarly to #162, it would be nice to refer to Reactive Streams **always** as "Reactive Streams".