### PR TITLE
Change application reserved error code range

### DIFF
--- a/Protocol.md
+++ b/Protocol.md
@@ -349,7 +349,7 @@ The Error Data is typically an Exception message, but could include stringified 
 | __RESERVED__                   | 0xFFFFFFFF | __Reserved for Extension Use__ |
 
 __NOTE__: Values in the range of 0x0001 to 0x00FF are reserved for use as SETUP error codes. Values in the range of
-0x00101 to 0x001FF are reserved for connection error codes. Values in the range of 0x00205 to 0xFFFFFFFE are reserved for application layer
+0x00101 to 0x001FF are reserved for connection error codes. Values in the range of 0x00301 to 0xFFFFFFFE are reserved for application layer
 errors.
 
 <a name="frame-lease"></a>

--- a/Protocol.md
+++ b/Protocol.md
@@ -348,9 +348,7 @@ The Error Data is typically an Exception message, but could include stringified 
 | __INVALID__                    | 0x00000204 | The request is invalid. Stream ID MUST be > 0. |
 | __RESERVED__                   | 0xFFFFFFFF | __Reserved for Extension Use__ |
 
-__NOTE__: Values in the range of 0x0001 to 0x00FF are reserved for use as SETUP error codes. Values in the range of
-0x00101 to 0x001FF are reserved for connection error codes. Values in the range of 0x00301 to 0xFFFFFFFE are reserved for application layer
-errors.
+__NOTE__: Unsed values in the range of 0x0001 to 0x00300 are reserved for future protocol use. Values in the range of 0x00301 to 0xFFFFFFFE are reserved for application layer errors.
 
 <a name="frame-lease"></a>
 ### LEASE Frame (0x02)

--- a/Protocol.md
+++ b/Protocol.md
@@ -349,7 +349,7 @@ The Error Data is typically an Exception message, but could include stringified 
 | __RESERVED__                   | 0xFFFFFFFF | __Reserved for Extension Use__ |
 
 __NOTE__: Values in the range of 0x0001 to 0x00FF are reserved for use as SETUP error codes. Values in the range of
-0x00101 to 0x001FF are reserved for connection error codes. Values in the range of 0x00201 to 0xFFFFFFFE are reserved for application layer
+0x00101 to 0x001FF are reserved for connection error codes. Values in the range of 0x00205 to 0xFFFFFFFE are reserved for application layer
 errors.
 
 <a name="frame-lease"></a>


### PR DESCRIPTION
We now have codes up to 204, so application needs to start at 205.