### PR TITLE
clarify HTTP/2 stream as transport with link

### DIFF
--- a/Protocol.md
+++ b/Protocol.md
@@ -94,7 +94,7 @@ The ReactiveSocket protocol uses a lower level transport protocol to carry React
 
 An implementation MAY "close" a transport connection due to protocol processing. When this occurs, it is assumed that the connection will have no further frames sent and all frames will be ignored.
 
-ReactiveSocket as specified here has been designed for and tested with TCP, WebSocket, and Aeron as transport protocols.
+ReactiveSocket as specified here has been designed for and tested with TCP, WebSocket, Aeron, and [HTTP/2 streams](https://http2.github.io/http2-spec/#StreamsLayer) as transport protocols.
 
 ### Framing Protocol Usage
 
@@ -107,7 +107,7 @@ The frame length field MUST be omitted if the transport protocol preserves messa
 | TCP                            | __YES__ |
 | WebSocket                      | __NO__  |
 | Aeron                          | __NO__  |
-| HTTP/2                         | __YES__ |
+| HTTP/2 Stream                  | __YES__ |
 
 ### Framing Format
 


### PR DESCRIPTION
Since HTTP/2 is referenced later, and we target it, I'm calling it out in the transport section, but being specific to it being HTTP/2 streams that we target, as most HTTP/2 clients don't expose stream APIs.