### PR TITLE
remove default metadata encoding

### DIFF
--- a/Protocol.md
+++ b/Protocol.md
@@ -77,7 +77,7 @@ between the types in an application is left to the application.
 
 The following are features of Data and Metadata.
 
-- Metadata can be encoded differently than Data. Default metadata encoding is specified in [this document](https://github.com/ReactiveSocket/reactivesocket/blob/master/MimeTypes.md)
+- Metadata can be encoded differently than Data.
 - Metadata can be "attached" (i.e. correlated) with the following entities:
     - Connection via Metadata Push and Stream ID of 0
     - Individual Request or Payload (upstream or downstream)


### PR DESCRIPTION
I suggest removal of this line. In practice no implementation does this, nor have I actually found this be usable, as every usage defines the mimetype in the client/server negotiation. Right now this rule means none of the implementations are actually compliant, and it requires dependency on CBOR since the default format is defined as: application/x.reactivesocket.meta+cbor