### PR TITLE
Use unsigned for all bit descriptions

### DIFF
--- a/Protocol.md
+++ b/Protocol.md
@@ -133,7 +133,7 @@ When using a transport protocol that does not provide compatible framing, the Fr
     +-----------------------------------------------+
 ```
 
-* __Frame Length__: (24 bits = max value 16,777,215) Unsigned integer representing the length of Frame in bytes. Excluding the Frame Length field.
+* __Frame Length__: (24 bits = max value 16,777,215) Unsigned 24-bit integer representing the length of Frame in bytes. Excluding the Frame Length field.
 
 __NOTE__: Byte ordering is big endian.
 
@@ -145,13 +145,13 @@ ReactiveSocket frames begin with a ReactiveSocket Frame Header. The general layo
      0                   1                   2                   3
      0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-    |                           Stream ID                           |
+    |0|                         Stream ID                           |
     +-----------+-+-+---------------+-------------------------------+
     |Frame Type |I|M|     Flags     |     Depends on Frame Type    ...
     +-------------------------------+
 ```
 
-* __Stream ID__: (32 bits = max value 2^31-1 = 2,147,483,647) Signed integer representing the stream Identifier for this frame or 0 to indicate the entire connection. Value MUST be >= 0.
+* __Stream ID__: (31 bits = max value 2^31-1 = 2,147,483,647) Unsigned 31-bit integer representing the stream Identifier for this frame or 0 to indicate the entire connection. Value MUST be >= 0.
   * Transport protocols that include demultiplexing, such as HTTP/2, MAY omit the Stream ID field if all parties agree. The means of negotiation and agreement is left to the transport protocol. 
 * __Frame Type__: (6 bits = max value 63) Type of Frame.
 * __Flags__: (10 bits) Any Flag bit not specifically indicated in the frame type should be set to 0 when sent and not interpreted on
@@ -191,7 +191,7 @@ If Metadata Length is greater than this value, the entire frame MUST be ignored.
     +---------------------------------------------------------------+
 ```
 
-* __Metadata Length__: (24 bits = max value 16,777,215) Unsigned integer representing the length of Metadata in bytes. Excluding Metadata Length field.
+* __Metadata Length__: (24 bits = max value 16,777,215) Unsigned 24-bit integer representing the length of Metadata in bytes. Excluding Metadata Length field.
 
 ### Stream Identifiers
 
@@ -256,9 +256,9 @@ Frame Contents
     +-----------+-+-+-+-+-+---------+-------------------------------+
     |         Major Version         |        Minor Version          |
     +-------------------------------+-------------------------------+
-    |                   Time Between KEEPALIVE Frames               |
+    |0|                 Time Between KEEPALIVE Frames               |
     +---------------------------------------------------------------+
-    |                         Max Lifetime                          |
+    |0|                       Max Lifetime                          |
     +---------------------------------------------------------------+
     |         Token Length          | Resume Identification Token  ...
     +---------------+-----------------------------------------------+
@@ -275,11 +275,11 @@ Frame Contents
      * (__R__)esume Enable: Client requests resume capability if possible. Resume Identification Token present.
      * (__L__)ease: Will honor LEASE (or not).
      * (__S__)trict: Adhere to strict interpretation of Data and Metadata.
-* __Major Version__: (16 bits = max value 65,535) Unsigned integer of Major version number of the protocol.
-* __Minor Version__: (16 bits = max value 65,535) Unsigned integer of Minor version number of the protocol.
-* __Time Between KEEPALIVE Frames__: (32 bits = max value 2^31-1 = 2,147,483,647) Signed integer of Time (in milliseconds) between KEEPALIVE frames that the client will send. Value MUST be > 0.
-* __Max Lifetime__: (32 bits = max value 2^31-1 = 2,147,483,647) Signed integer of Time (in milliseconds) that a client will allow a server to not respond to a KEEPALIVE before it is assumed to be dead. Value MUST be > 0. 
-* __Resume Identification Token Length__: (16 bits = max value 65,535) Unsigned integer of Resume Identification Token Length in bytes. (Not present if R flag is not set)
+* __Major Version__: (16 bits = max value 65,535) Unsigned 16-bit integer of Major version number of the protocol.
+* __Minor Version__: (16 bits = max value 65,535) Unsigned 16-bit integer of Minor version number of the protocol.
+* __Time Between KEEPALIVE Frames__: (31 bits = max value 2^31-1 = 2,147,483,647) Unsigned 31-bit integer of Time (in milliseconds) between KEEPALIVE frames that the client will send. Value MUST be > 0.
+* __Max Lifetime__: (31 bits = max value 2^31-1 = 2,147,483,647) Unsigned 31-bit integer of Time (in milliseconds) that a client will allow a server to not respond to a KEEPALIVE before it is assumed to be dead. Value MUST be > 0. 
+* __Resume Identification Token Length__: (16 bits = max value 65,535) Unsigned 16-bit integer of Resume Identification Token Length in bytes. (Not present if R flag is not set)
 * __Resume Identification Token__: Token used for client resume identification (Not present if R flag is not set)
 * __MIME Length__: Encoding MIME Type Length in bytes.
 * __Encoding MIME Type__: MIME Type for encoding of Data and Metadata. This SHOULD be a US-ASCII string
@@ -370,9 +370,9 @@ Frame Contents
     +-----------+-+-+---------------+-------------------------------+
     |Frame Type |0|M|     Flags     |
     +-----------+-+-+---------------+-------------------------------+
-    |                         Time-To-Live                          |
+    |0|                       Time-To-Live                          |
     +---------------------------------------------------------------+
-    |                       Number of Requests                      |
+    |0|                     Number of Requests                      |
     +---------------------------------------------------------------+
                                 Metadata
 ```
@@ -380,8 +380,8 @@ Frame Contents
 * __Frame Type__: (6 bits = max value 63) 0x02 
 * __Flags__: (10 bits)
      * (__M__)etadata: Metadata present
-* __Time-To-Live (TTL)__: (32 bits = max value 2^31-1 = 2,147,483,647) Signed integer of Time (in milliseconds) for validity of LEASE from time of reception. Value MUST be > 0. 
-* __Number of Requests__: (32 bits = max value 2^31-1 = 2,147,483,647) Signed integer of Number of Requests that may be sent until next LEASE. Value MUST be > 0. 
+* __Time-To-Live (TTL)__: (31 bits = max value 2^31-1 = 2,147,483,647) Unsigned 31-bit integer of Time (in milliseconds) for validity of LEASE from time of reception. Value MUST be > 0. 
+* __Number of Requests__: (31 bits = max value 2^31-1 = 2,147,483,647) Unsigned 31-bit integer of Number of Requests that may be sent until next LEASE. Value MUST be > 0. 
 
 A Responder implementation MAY stop all further requests by sending a LEASE with a value of 0 for __Number of Requests__ or __Time-To-Live__.
 
@@ -415,7 +415,7 @@ Frame Contents
     +-----------+-+-+-+-------------+-------------------------------+
     |Frame Type |0|0|R|    Flags    |
     +-----------+-+-+-+-------------+-------------------------------+
-    |                    Last Received Position                     |
+    |0|                  Last Received Position                     |
     +                                                               +
     |                                                               |
     +---------------------------------------------------------------+
@@ -425,7 +425,7 @@ Frame Contents
 * __Frame Type__: (6 bits = max value 63) 0x03
 * __Flags__: (10 bits)
      * (__R__)espond with KEEPALIVE or not
-* __Last Received Position__: (64 bits = max value 2^63-1) Signed long of Resume Last Received Position. Value MUST be > 0. (optional. Set to all 0s when not supported.)
+* __Last Received Position__: (63 bits = max value 2^63-1) Unsigned 63-bit long of Resume Last Received Position. Value MUST be > 0. (optional. Set to all 0s when not supported.)
 * __Data__: Data attached to a KEEPALIVE.
 
 <a name="frame-request-response"></a>
@@ -485,7 +485,7 @@ Frame Contents
     +-----------+-+-+-+-------------+-------------------------------+
     |Frame Type |0|M|F|    Flags    |
     +-------------------------------+-------------------------------+
-    |                      Initial Request N                        |
+    |0|                    Initial Request N                        |
     +---------------------------------------------------------------+
                           Metadata & Request Data
 ```
@@ -494,7 +494,7 @@ Frame Contents
 * __Flags__: (10 bits)
     * (__M__)etadata: Metadata present
     * (__F__)ollows: More fragments follow this fragment.
-* __Initial Request N__: (32 bits = max value 2^31-1 = 2,147,483,647) Signed integer representing the initial number of items to request. Value MUST be > 0.
+* __Initial Request N__: (31 bits = max value 2^31-1 = 2,147,483,647) Unsigned 31-bit integer representing the initial number of items to request. Value MUST be > 0.
 * __Request Data__: identification of the service being requested along with parameters for the request.
 
 See Flow Control: Reactive Streams Semantics for more information on RequestN behavior.
@@ -512,7 +512,7 @@ Frame Contents
     +-----------+-+-+-+-+-----------+-------------------------------+
     |Frame Type |0|M|F|C|  Flags    |
     +-------------------------------+-------------------------------+
-    |                      Initial Request N                        |
+    |0|                    Initial Request N                        |
     +---------------------------------------------------------------+
                            Metadata & Request Data
 ```
@@ -522,7 +522,7 @@ Frame Contents
     * (__M__)etadata: Metadata present
     * (__F__)ollows: More fragments follow this fragment.
     * (__C__)omplete: bit to indicate COMPLETE.
-* __Initial Request N__: (32 bits = max value 2^31-1 = 2,147,483,647) Signed integer representing the initial request N value for channel. Value MUST be > 0.
+* __Initial Request N__: (31 bits = max value 2^31-1 = 2,147,483,647) Unsigned 31-bit integer representing the initial request N value for channel. Value MUST be > 0.
 * __Request Data__: identification of the service being requested along with parameters for the request.
 
 A requester MUST send only __one__ REQUEST_CHANNEL frame. Subsequent messages from requester to responder MUST be sent as PAYLOAD frames. 
@@ -544,12 +544,12 @@ Frame Contents
     +-----------+-+-+---------------+-------------------------------+
     |Frame Type |0|0|     Flags     |
     +-------------------------------+-------------------------------+
-    |                           Request N                           |
+    |0|                         Request N                           |
     +---------------------------------------------------------------+
 ```
 
 * __Frame Type__: (6 bits = max value 63) 0x08
-* __Request N__: (32 bits = max value 2^31-1 = 2,147,483,647) Signed integer representing the number of items to request. Value MUST be > 0.
+* __Request N__: (31 bits = max value 2^31-1 = 2,147,483,647) Unsigned 31-bit integer representing the number of items to request. Value MUST be > 0.
 
 See Flow Control: Reactive Streams Semantics for more information on RequestN behavior.
 
@@ -641,7 +641,7 @@ The general format for an extension frame is given below.
     +-----------+-+-+---------------+-------------------------------+
     |Frame Type |I|M|    Flags      |
     +-------------------------------+-------------------------------+
-    |                        Extended Type                          |
+    |0|                      Extended Type                          |
     +---------------------------------------------------------------+
                           Depends on Extended Type...
 ```
@@ -650,7 +650,7 @@ The general format for an extension frame is given below.
 * __Flags__: (10 bits)
     * (__I__)gnore: Can the frame be ignored if not understood?
     * (__M__)etadata: Metadata Present.
-* __Extended Type__: (32 bits = max value 2^31-1 = 2,147,483,647) Signed integer of Extended type information. Value MUST be > 0.
+* __Extended Type__: (31 bits = max value 2^31-1 = 2,147,483,647) Unsigned 31-bit integer of Extended type information. Value MUST be > 0.
 
 ## Resuming Operation
 
@@ -737,23 +737,23 @@ RESUME frames MUST always use Stream ID 0 as they pertain to the connection.
     +-------------------------------+-------------------------------+
     |         Token Length          | Resume Identification Token  ...
     +---------------------------------------------------------------+
-    |                                                               |
+    |0|                                                             |
     +                 Last Received Server Position                 +
     |                                                               |
     +---------------------------------------------------------------+
-    |                                                               |
+    |0|                                                             |
     +                First Available Client Position                +
     |                                                               |
     +---------------------------------------------------------------+
 ```
 
 * __Frame Type__: (6 bits = max value 63) 0x0D
-* __Major Version__: (16 bits = max value 65,535) Unsigned integer of Major version number of the protocol.
-* __Minor Version__: (16 bits = max value 65,535) Unsigned integer of Minor version number of the protocol.
-* __Resume Identification Token Length__: (16 bits = max value 65,535) Unsigned integer of Resume Identification Token Length in bytes. 
+* __Major Version__: (16 bits = max value 65,535) Unsigned 16-bit integer of Major version number of the protocol.
+* __Minor Version__: (16 bits = max value 65,535) Unsigned 16-bit integer of Minor version number of the protocol.
+* __Resume Identification Token Length__: (16 bits = max value 65,535) Unsigned 16-bit integer of Resume Identification Token Length in bytes. 
 * __Resume Identification Token__: Token used for client resume identification. Same Resume Identification used in the initial SETUP by the client.
-* __Last Received Server Position__: (64 bits = max value 2^63-1) Signed long of the last implied position the client received from the server. Value MUST be >= 0.
-* __First Available Client Position__: (64 bits = max value 2^63-1) Signed long of the earliest position that the client can rewind back to prior to resending frames. Value MUST be >= 0.
+* __Last Received Server Position__: (63 bits = max value 2^63-1) Unsigned 63-bit long of the last implied position the client received from the server. Value MUST be >= 0.
+* __First Available Client Position__: (63 bits = max value 2^63-1) Unsigned 63-bit long of the earliest position that the client can rewind back to prior to resending frames. Value MUST be >= 0.
 
 <a name="frame-resume-ok"></a>
 #### RESUME_OK Frame (0x0E)
@@ -770,14 +770,14 @@ RESUME OK frames MUST always use Stream ID 0 as they pertain to the connection.
     +-----------+-+-+---------------+-------------------------------+
     |Frame Type |0|0|    Flags      |
     +-------------------------------+-------------------------------+
-    |                                                               |
+    |0|                                                             |
     +               Last Received Client Position                   +
     |                                                               |
     +---------------------------------------------------------------+
 ```
 
 * __Frame Type__: (6 bits = max value 63) 0x0E
-* __Last Received Client Position__: (64 bits = max value 2^63-1) Signed long of the last implied position the server received from the client. Value MUST be >= 0.
+* __Last Received Client Position__: (63 bits = max value 2^63-1) Unsigned 63-bit long of the last implied position the server received from the client. Value MUST be >= 0.
 
 #### Keepalive Position Field
 


### PR DESCRIPTION
Based on feedback, adopting the style of description used by HTTP/2 (http://httpwg.org/specs/rfc7540.html#FrameHeader) and specifically showing the first bit of 32-bit and 64-bit numbers to always be 0.