### PR TITLE
Remove Metadata from CANCEL & ERROR

### DIFF
--- a/Protocol.md
+++ b/Protocol.md
@@ -375,15 +375,18 @@ Frame Contents
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
     |                         Stream ID = 0                         |
     +-----------+-+-+---------------+-------------------------------+
-    |Frame Type |0|0|     Flags     |
+    |Frame Type |0|M|     Flags     |
     +-----------+-+-+---------------+-------------------------------+
     |0|                       Time-To-Live                          |
     +---------------------------------------------------------------+
     |0|                     Number of Requests                      |
     +---------------------------------------------------------------+
+                                Metadata
 ```
 
 * __Frame Type__: (6 bits = max value 63) 0x02 
+* __Flags__: (10 bits)
+     * (__M__)etadata: Metadata present
 * __Time-To-Live (TTL)__: (31 bits = max value 2^31-1 = 2,147,483,647) Unsigned 31-bit integer of Time (in milliseconds) for validity of LEASE from time of reception. Value MUST be > 0. 
 * __Number of Requests__: (31 bits = max value 2^31-1 = 2,147,483,647) Unsigned 31-bit integer of Number of Requests that may be sent until next LEASE. Value MUST be > 0. 
 

--- a/Protocol.md
+++ b/Protocol.md
@@ -318,16 +318,14 @@ Frame Contents
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
     |                           Stream ID                           |
     +-----------+-+-+---------------+-------------------------------+
-    |Frame Type |0|M|      Flags    |
+    |Frame Type |0|0|      Flags    |
     +-----------+-+-+---------------+-------------------------------+
     |                          Error Code                           |
     +---------------------------------------------------------------+
-                        Metadata & Error Data
+                               Error Data
 ```
 
 * __Frame Type__: (6 bits = max value 63) 0x0B
-* __Flags__: (10 bits)
-     * (__M__)etadata: Metadata present
 * __Error Code__: (32 bits = max value 2^31-1 = 2,147,483,647) Type of Error.
      * See list of valid Error Codes below.
 * __Error Data__: includes Payload describing error information. Error Data SHOULD be a UTF-8 encoded string. The string MUST NOT be null terminated.
@@ -377,18 +375,15 @@ Frame Contents
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
     |                         Stream ID = 0                         |
     +-----------+-+-+---------------+-------------------------------+
-    |Frame Type |0|M|     Flags     |
+    |Frame Type |0|0|     Flags     |
     +-----------+-+-+---------------+-------------------------------+
     |0|                       Time-To-Live                          |
     +---------------------------------------------------------------+
     |0|                     Number of Requests                      |
     +---------------------------------------------------------------+
-                                Metadata
 ```
 
 * __Frame Type__: (6 bits = max value 63) 0x02 
-* __Flags__: (10 bits)
-     * (__M__)etadata: Metadata present
 * __Time-To-Live (TTL)__: (31 bits = max value 2^31-1 = 2,147,483,647) Unsigned 31-bit integer of Time (in milliseconds) for validity of LEASE from time of reception. Value MUST be > 0. 
 * __Number of Requests__: (31 bits = max value 2^31-1 = 2,147,483,647) Unsigned 31-bit integer of Number of Requests that may be sent until next LEASE. Value MUST be > 0. 
 
@@ -573,14 +568,11 @@ Frame Contents
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
     |                           Stream ID                           |
     +-----------+-+-+---------------+-------------------------------+
-    |Frame Type |0|M|    Flags      |
+    |Frame Type |0|0|    Flags      |
     +-------------------------------+-------------------------------+
-                                Metadata
 ```
 
 * __Frame Type__: (6 bits = max value 63) 0x09
-* __Flags__: (10 bits)
-     * (__M__)etadata: Metadata present
 
 <a name="frame-payload"></a>
 ### PAYLOAD Frame (0x0A)

--- a/Protocol.md
+++ b/Protocol.md
@@ -347,7 +347,7 @@ The Error Data is typically an Exception message, but could include stringified 
 | __CONNECTION_ERROR__           | 0x00000101 | The connection is being terminated. Stream ID MUST be 0. Sender or Receiver of this frame MAY close the connection immediately without waiting for outstanding streams to terminate.|
 | __CONNECTION_CLOSE__           | 0x00000102 | The connection is being terminated. Stream ID MUST be 0. Sender or Receiver of this frame MUST wait for outstanding streams to terminate before closing the connection. New requests MAY not be accepted.|
 | __APPLICATION_ERROR__          | 0x00000201 | Application layer logic generating a Reactive Streams _onError_ event. Stream ID MUST be > 0. |
-| __REJECTED__                   | 0x00000202 | Despite being a valid request, the Responder decided to reject it. The Responder guarantees that it didn't process the request. The reason for the rejection is explained in the metadata section. Stream ID MUST be > 0. |
+| __REJECTED__                   | 0x00000202 | Despite being a valid request, the Responder decided to reject it. The Responder guarantees that it didn't process the request. The reason for the rejection is explained in the Error Data section. Stream ID MUST be > 0. |
 | __CANCELED__                   | 0x00000203 | The responder canceled the request but potentially have started processing it (almost identical to REJECTED but doesn't garantee that no side-effect have been started). Stream ID MUST be > 0. |
 | __INVALID__                    | 0x00000204 | The request is invalid. Stream ID MUST be > 0. |
 | __RESERVED__                   | 0xFFFFFFFF | __Reserved for Extension Use__ |


### PR DESCRIPTION
As per discussion in https://github.com/ReactiveSocket/reactivesocket/issues/201, remove Metadata from ERROR, LEASE, and CANCEL frames.